### PR TITLE
chore: comment out Vercel adapter and Speed Insights script

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -7,9 +7,9 @@ import mdx from '@astrojs/mdx';
 
 // https://astro.build/config
 export default defineConfig({
-  adapter: vercel({
-    webAnalytics: { enabled: true },
-  }),
+  // adapter: vercel({
+  //   webAnalytics: { enabled: true },
+  // }),
   integrations: [
     solid(),
     unocss({

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -32,9 +32,9 @@ const { title, description } = Astro.props;
         </div>
       </div>
     </ThemeProvider>
-    <script>
-      import { injectSpeedInsights } from '@vercel/speed-insights';
-      injectSpeedInsights();
-    </script>
+    <!-- <script> -->
+    <!--   import { injectSpeedInsights } from '@vercel/speed-insights'; -->
+    <!--   injectSpeedInsights(); -->
+    <!-- </script> -->
   </body>
 </html>


### PR DESCRIPTION
- Temporarily disabled Vercel adapter configuration in `astro.config.ts`.
- Commented out Speed Insights script injection in `Base.astro`.