### PR TITLE
feat(RepoCard): add hover scaling effect for enhanced interactivity

### DIFF
--- a/src/components/RepoCard.astro
+++ b/src/components/RepoCard.astro
@@ -19,8 +19,9 @@ const [, name] = repo.split('/');
     class="flex items-center justify-between
     rounded-lg
     p-4
-    transition-shadow
-    duration-300"
+    transition-all
+    duration-300
+    hover:scale-101"
     shadow="~ dark:primary hover:lg"
     bg="accent-0 dark:accent-1"
     text="white dark:text-0"


### PR DESCRIPTION
- Replaced `transition-shadow` with `transition-all` for smoother animations.
- Introduced `hover:scale-101` to apply a subtle scaling effect on hover.